### PR TITLE
Add dependency for postgresql support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 	quassel-core \
+	libqt4-sql-psql \
 	libqca2-plugin-ossl libicu52
 
 USER quasselcore


### PR DESCRIPTION
Hi, thanks for the Dockerfile. I'm using it and it works great.

I wanted to use it with PostgreSQL but a package was missing.
